### PR TITLE
trim public path prefix

### DIFF
--- a/backends/gcs/get.go
+++ b/backends/gcs/get.go
@@ -39,12 +39,15 @@ func Read(ctx context.Context, response http.ResponseWriter,
 
 func ReadWithSignatureURL(ctx context.Context, response http.ResponseWriter,
 	request *http.Request, pipeline filter.Pipeline) {
+	max_age := 6 * 24 * 60 * time.Minute
 	objectName := common.NormalizePath(request.Header.Get("x-lpse-id"), request.URL.Path)
 	opts := &storage.SignedURLOptions{
 		Scheme:  storage.SigningSchemeV4,
 		Method:  "GET",
-		Expires: time.Now().Add(24 * 6 * time.Hour),
+		Expires: time.Now().Add(max_age),
 	}
+	cacheControl := "private, max-age=" + fmt.Sprintf("%.0f", max_age.Seconds())
+	response.Header().Set("Cache-Control", cacheControl)
 	url, signedErr := gcs.Bucket(bucket).SignedURL(objectName, opts)
 	if signedErr != nil {
 		log.Error().Msgf("Bucket(%q).SignedURL: %w", bucket, signedErr)

--- a/backends/gcs/get.go
+++ b/backends/gcs/get.go
@@ -70,7 +70,7 @@ func ReadWithCache(ctx context.Context, response http.ResponseWriter,
 	request *http.Request, missPipeline filter.Pipeline, cacheGet CacheGet,
 	hitPipeline filter.Pipeline) {
 	// normalize path
-	objectName := common.NormalizePath(request.Header.Get("x-lpse-id"), request.URL.Path)
+	objectName := common.NormalizePathForPublicGet(request.Header.Get("x-lpse-id"), request.URL.Path)
 
 	// get the object handle and headers. Headers are always cached and obey
 	// Cache-Control header, so this will not call GCS unless there's a miss.

--- a/cmd/domain/file/handler.go
+++ b/cmd/domain/file/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DomZippilli/gcs-proxy-cloud-function/backends/shared-libs/go/logger"
 	"github.com/DomZippilli/gcs-proxy-cloud-function/backends/shared-libs/go/respond"
 	"github.com/DomZippilli/gcs-proxy-cloud-function/common"
+	"github.com/agrison/go-commons-lang/stringUtils"
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog/log"
 )
@@ -40,6 +41,10 @@ func (ths *handler) HealthCheck(w http.ResponseWriter, req *http.Request) {
 }
 
 func (ths *handler) UploadFile(w http.ResponseWriter, req *http.Request) {
+	if stringUtils.IsEmpty(req.Header.Get("x-lpse-id")) {
+		http.Error(w, "x-lpse-id header not found", http.StatusBadRequest)
+		return
+	}
 	enableCors(&w)
 	var input FileUploadReq
 	err := json.NewDecoder(req.Body).Decode(&input)

--- a/cmd/domain/file/handler.go
+++ b/cmd/domain/file/handler.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -115,6 +116,7 @@ func (ths *handler) DownloadFile(w http.ResponseWriter, req *http.Request) {
 		log.Info().Msgf("Download fileID %s will be redirected to publicUrl %s", id, res.PublicUrl)
 		http.Redirect(w, req, res.PublicUrl, http.StatusMovedPermanently)
 	}
+	w.Header().Set("Cache-Control", "private, max-age="+fmt.Sprintf("%d", (6*24*60*60)))
 	respond.Success(w, res, http.StatusOK)
 }
 

--- a/cmd/domain/file/service.go
+++ b/cmd/domain/file/service.go
@@ -95,7 +95,7 @@ func (ths *service) DownloadFile(ctx context.Context, input string) (*uploadercl
 	tmp = append(tmp, input)
 	file, _ := ths.uploaderClient.RequestDownloadUrl(commonutils.ReqIDFromContext(ctx), uploaderclient.RequestDownloadUrlReq{
 		Token:          tmp,
-		ExpiryInSecond: 10000,
+		ExpiryInSecond: 6 * 24 * 60 * 60,
 	})
 	return &file[0], nil
 }

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/agrison/go-commons-lang/stringUtils"
 	"github.com/rs/zerolog/log"
 )
 
@@ -28,17 +27,14 @@ import (
 //	replace trailing slashes with "/index.html";
 //	remove leading slashes.
 func NormalizePath(prefix string, path string) (object string) {
-	if strings.HasSuffix(path, "/") {
-		path = path + "index.html"
-	}
-
-	//TODO: CONFIGURIZE THE PREFIX AND CHANGE THE PREFIX
-	if stringUtils.IsEmpty(prefix) {
-		prefix = "121"
-	}
-	result := prefix + "/" + strings.TrimLeft(path, "/")
+	result := prefix + path
 	log.Info().Msgf("normalized path: %s", result)
 	return result
+}
+
+func NormalizePathForPublicGet(prefix string, path string) (object string) {
+	path = path[strings.Index(path, "/public/"):]
+	return NormalizePath(prefix, path)
 }
 
 func GetRuntimeProjectId() (string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/DomZippilli/gcs-proxy-cloud-function/backends/gcs"
+	"github.com/agrison/go-commons-lang/stringUtils"
 	"github.com/rs/zerolog/log"
 )
 
@@ -30,6 +31,10 @@ func Setup() error {
 
 // GET will be called in main.go for GET requests
 func GET(ctx context.Context, output http.ResponseWriter, input *http.Request) {
+	if stringUtils.IsEmpty(input.Header.Get("x-lpse-id")) {
+		http.Error(output, "x-lpse-id header not found", http.StatusBadRequest)
+		return
+	}
 	log.Info().Msgf("GET triggered with path: %q", input.URL.Path)
 
 	requestHeadersJson, err := json.Marshal(input.Header)
@@ -38,7 +43,7 @@ func GET(ctx context.Context, output http.ResponseWriter, input *http.Request) {
 	}
 	log.Info().Msgf("request header: %q", string(requestHeadersJson))
 
-	if strings.Contains(input.URL.Path, "public") {
+	if strings.Contains(input.URL.Path, "/public/") {
 		gcs.Read(ctx, output, input, LoggingOnly)
 	} else {
 		gcs.ReadWithSignatureURL(ctx, output, input, LoggingOnly)

--- a/deploy.sh
+++ b/deploy.sh
@@ -59,6 +59,7 @@ gcloud run deploy "gcs-spse-dev-bucket" \
     --cpu=2 \
     --memory=1Gi \
     --concurrency=100 \
+    --min-instances=1 \
     --max-instances=1 \
     --timeout=300s \
     --platform managed \


### PR DESCRIPTION
Changes:

1. Altering the behaviour when getting for **public** object in GCS 
    - path input from client => `**/public/images/**`
    - proxy service will get object to  => `{x-lpse-id}/public/images/**`

2. if x-lpse-id is not present when Upload and Get (by path) is triggerred, BadRequest http error will be thrown